### PR TITLE
Add pre-release identifier input box

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,17 @@
         "command": "bump-npm-package-version",
         "title": "Bump NPM Package Version"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "NPM Package Version Bumper",
+      "properties": {
+        "npm-package-version-bumper.preid": {
+          "type": ["string", "null"],
+          "default": null,
+          "description": "Specifies the preid to use for the npm version."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
@@ -40,9 +50,8 @@
   },
   "devDependencies": {
     "@types/node": "12.7.4",
-    "@types/vscode": "1.7.1",
-    "typescript": "3.6.2",
+    "@types/vscode": "^1.7.1",
+    "typescript": "^4.3.2",
     "vsce": "1.66.0"
-  },
-  "dependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -29,17 +29,7 @@
         "command": "bump-npm-package-version",
         "title": "Bump NPM Package Version"
       }
-    ],
-    "configuration": {
-      "title": "NPM Package Version Bumper",
-      "properties": {
-        "npm-package-version-bumper.preid": {
-          "type": ["string", "null"],
-          "default": null,
-          "description": "Specifies the preid to use for the npm version."
-        }
-      }
-    }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/source/extension.ts
+++ b/source/extension.ts
@@ -44,10 +44,12 @@ class Extension {
     // Prepare command & arguments
     let command = `npm version ${picked}`;
 
-    const configuredPreId = workspace.getConfiguration().get('npm-package-version-bumper.preid');
+    if (picked === 'prerelease') {
+      const preid = await window.showInputBox({"placeHolder": "Pre-Release Identifier"});
 
-    if (configuredPreId !== null) {
-      command += ` --preid=${configuredPreId}`;
+      if (preid !== undefined && preid.trim() !== "") {
+        command += ` --preid=${preid}`;
+      }
     }
 
     const commandArguments = {


### PR DESCRIPTION
Hello!

I just added an input box when the pre-release option is picked to be able to set the pre-release identifier so we can generate versions that look like 1.0.0-beta.1, -beta.2...

Love your extension, great work.

Thanks.