### PR TITLE
Add pre-identifier input to pre versions

### DIFF
--- a/source/extension.ts
+++ b/source/extension.ts
@@ -64,7 +64,7 @@ async function handleOnBumpNpmPackageVerisonCommand() {
     let command = `npm version ${picked}`;
 
     // pre-id
-    if (picked === "prerelease") {
+    if (picked.includes("pre")) {
       const preid = await window.showInputBox({
         placeHolder: "Pre-Release Identifier",
       });


### PR DESCRIPTION
Hello,

This very basic change allows to switch identifiers when bumping to a pre version, for example if I'm on a stable version with no pre identifier and I'd like to create a pre patch version with the beta identifier a modal will know appear for me to add the identifier.

Same for the major and minor pre-versions.

Thanks!